### PR TITLE
Fixed formatting, constrained the max display size

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -7,12 +7,15 @@
   	<!-- Latest compiled and minified CSS -->
   	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css">
     <style type="text/css">
+		div.container-fluid{max-width: 900px}
 		div.banner{text-align: center}
 		div.jadep{height: 90px; line-height: 90px; font-size: 250%}
-		span {display: inline-block; vertical-align: middle; line-height: normal}
-		div.content{padding: 30px 0}	
-		div.contact-info{text-align: center}
-		a.lnk{color: gray}
+		span {display: inline-block; vertical-align: middle; line-height: normal}	
+		div.picture{display: inline-block; vertical-align: middle; text-align:center; min-width:150px; padding: 0 30px 30px 30px}
+        div.column{display: inline-block; vertical-align: top}
+        div.content{padding: 30px 0}	
+        a{color: gray}
+        div.contact-info{text-align: center}
   	</style>
   	<!--[if lt IE 9]>
     	<script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -7,10 +7,11 @@
   	<!-- Latest compiled and minified CSS -->
   	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"> 
   	<style type="text/css">
+  	    div.container-fluid{max-width: 900px}
 		div.banner{text-align: center}
 		div.jadep{height: 90px; line-height: 90px; font-size: 250%}
 		span {display: inline-block; vertical-align: middle; line-height: normal}	
-		div.picture{display: inline-block; vertical-align: middle; text-align:center; min-width:150px}
+		div.picture{display: inline-block; vertical-align: middle; text-align:center; min-width:150px; padding: 0 30px 30px 30px}
         div.column{display: inline-block; vertical-align: top}
         div.content{padding: 30px 0}	
         a{color: gray}

--- a/publications.html
+++ b/publications.html
@@ -7,10 +7,14 @@
   	<!-- Latest compiled and minified CSS -->
   	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css">
     <style type="text/css">
+  	    div.container-fluid{max-width: 900px}
 		div.banner{text-align: center}
 		div.jadep{height: 90px; line-height: 90px; font-size: 250%}
 		span {display: inline-block; vertical-align: middle; line-height: normal}	
-		div.content{padding: 30px 0}	
+		div.picture{display: inline-block; vertical-align: middle; text-align:center; min-width:150px; padding: 0 30px 30px 30px}
+        div.column{display: inline-block; vertical-align: top}
+        div.content{padding: 30px 0}	
+        a{color: gray}	
   	</style>
   	<!--[if lt IE 9]>
     	<script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>

--- a/resume.html
+++ b/resume.html
@@ -7,11 +7,14 @@
   	<!-- Latest compiled and minified CSS -->
   	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css">
     <style type="text/css">
+		div.container-fluid{max-width: 900px}
 		div.banner{text-align: center}
 		div.jadep{height: 90px; line-height: 90px; font-size: 250%}
-		span {display: inline-block; vertical-align: middle; line-height: normal}
-		div.content{padding: 30px 0}	
-		a{color: black}	
+		span {display: inline-block; vertical-align: middle; line-height: normal}	
+		div.picture{display: inline-block; vertical-align: middle; text-align:center; min-width:150px; padding: 0 30px 30px 30px}
+        div.column{display: inline-block; vertical-align: top}
+        div.content{padding: 30px 0}	
+        a{color: gray}
   	</style>
   	<!--[if lt IE 9]>
     	<script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>


### PR DESCRIPTION
Added some more padding around the picture, also constrained the max size of the container to 900px, it looks less in-your-face that way on bigger screens (like my laptop) -- this could be too small though for people with massive screens. Ideal would be filling up the whole screen for mobile devices and taking % of screen for normal browsers, but that is something I'll think about after fixing that god-awful publications section.